### PR TITLE
Add bulk payment modal for multi-invoice payment allocation

### DIFF
--- a/Components/Pages/CustomerInvoices.razor
+++ b/Components/Pages/CustomerInvoices.razor
@@ -2,6 +2,7 @@
 @page "/customer/{customerId:int}/invoices"
 @using Invoqs.Components.UI
 @using Invoqs.Models
+@using System.Linq
 
 <PageTitle>Τιμολόγια Πελάτη - Invoqs</PageTitle>
 
@@ -34,6 +35,13 @@
                         <i class="bi bi-arrow-left me-1"></i>
                         Επιστροφή στον Πελάτη
                     </button>
+                    @if (outstandingInvoices.Any())
+                    {
+                        <button class="btn btn-success" @onclick="ShowBulkPaymentModal">
+                            <i class="bi bi-cash-stack me-1"></i>
+                            Καταγραφή Πληρωμής
+                        </button>
+                    }
                     <a href="/customer/@CustomerId/invoice/new?returnUrl=@Uri.EscapeDataString(Navigation.Uri)"
                         class="btn btn-primary">
                         <i class="bi bi-plus-lg me-1"></i>
@@ -291,15 +299,22 @@
             @foreach (var invoice in filteredInvoices)
             {
                 <div class="col-xl-4 col-lg-6 col-md-6 mb-4">
-                    <InvoiceCard Invoice="invoice" 
-                                OnView="HandleViewInvoice" 
+                    <InvoiceCard Invoice="invoice"
+                                OnView="HandleViewInvoice"
                                 OnEdit="HandleEditInvoice"
-                                OnMarkAsSent="HandleMarkAsSent" 
+                                OnMarkAsSent="HandleMarkAsSent"
                                 OnMarkAsDelivered="HandleMarkAsDelivered"
-                                OnMarkAsPaid="HandleMarkAsPaid" 
+                                OnMarkAsPaid="HandleMarkAsPaid"
                                 OnCancel="HandleCancelInvoice" />
                 </div>
             }
         </div>
     }
 </div>
+
+@if (showBulkPaymentModal)
+{
+    <BulkPaymentModal OutstandingInvoices="outstandingInvoices"
+                      OnConfirm="HandleBulkPayment"
+                      OnCancel="() => showBulkPaymentModal = false" />
+}

--- a/Components/Pages/CustomerInvoices.razor.cs
+++ b/Components/Pages/CustomerInvoices.razor.cs
@@ -3,6 +3,7 @@ using Invoqs.Models;
 using Invoqs.Interfaces;
 using Microsoft.JSInterop;
 using Invoqs.Components.UI;
+using System.Linq;
 
 namespace Invoqs.Components.Pages
 {
@@ -25,6 +26,10 @@ namespace Invoqs.Components.Pages
         protected List<InvoiceModel> customerInvoices = new();
         protected decimal totalValue = 0;
         protected decimal totalOutstanding = 0;
+
+        // Bulk payment state
+        protected bool showBulkPaymentModal = false;
+        protected List<InvoiceModel> outstandingInvoices = new();
 
         // Filter state
         protected string searchTerm = "";
@@ -67,11 +72,13 @@ namespace Invoqs.Components.Pages
 
                 // Calculate totals
                 totalValue = customerInvoices.Sum(i => i.Total);
-                totalOutstanding = customerInvoices
+                outstandingInvoices = customerInvoices
                     .Where(i => i.Status == InvoiceStatus.Sent ||
                                 i.Status == InvoiceStatus.Delivered ||
-                                i.Status == InvoiceStatus.Overdue)
-                    .Sum(i => i.Total);
+                                i.Status == InvoiceStatus.Overdue ||
+                                i.Status == InvoiceStatus.PartiallyPaid)
+                    .ToList();
+                totalOutstanding = outstandingInvoices.Sum(i => i.RemainingAmount);
             }
             catch (Exception ex)
             {
@@ -247,6 +254,42 @@ namespace Invoqs.Components.Pages
             catch (Exception ex)
             {
                 errorMessage = $"Error marking invoice as paid: {ex.Message}";
+                StateHasChanged();
+            }
+        }
+
+        protected void ShowBulkPaymentModal()
+        {
+            showBulkPaymentModal = true;
+        }
+
+        protected async Task HandleBulkPayment(BulkPaymentConfirmArgs args)
+        {
+            try
+            {
+                var success = await InvoiceService.RecordBulkPaymentAsync(
+                    args.Allocations,
+                    args.PaymentDate,
+                    args.PaymentMethod,
+                    args.PaymentReference
+                );
+
+                showBulkPaymentModal = false;
+
+                if (success)
+                {
+                    await LoadData();
+                }
+                else
+                {
+                    errorMessage = "Αποτυχία καταγραφής πληρωμής. Παρακαλώ προσπαθήστε ξανά.";
+                    StateHasChanged();
+                }
+            }
+            catch (Exception ex)
+            {
+                showBulkPaymentModal = false;
+                errorMessage = $"Σφάλμα κατά την καταγραφή πληρωμής: {ex.Message}";
                 StateHasChanged();
             }
         }

--- a/Components/UI/BulkPaymentModal.razor
+++ b/Components/UI/BulkPaymentModal.razor
@@ -1,0 +1,116 @@
+@using Invoqs.Models
+
+<div class="modal show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Καταγραφή Πληρωμής Πελάτη</h5>
+                <button type="button" class="btn-close" @onclick="OnCancel"></button>
+            </div>
+            <div class="modal-body">
+
+                <!-- Payment details -->
+                <div class="row g-3 mb-4">
+                    <div class="col-md-3">
+                        <label class="form-label">Συνολικό Ποσό Πληρωμής <span class="text-danger">*</span></label>
+                        <div class="input-group">
+                            <span class="input-group-text">€</span>
+                            <input type="number" class="form-control" value="@totalPaymentAmount"
+                                   @oninput="OnTotalAmountChanged" step="0.01" min="0.01" />
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Ημερομηνία Πληρωμής <span class="text-danger">*</span></label>
+                        <input type="date" class="form-control" @bind="paymentDate" />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Μέθοδος Πληρωμής <span class="text-danger">*</span></label>
+                        <select class="form-select" @bind="paymentMethod">
+                            <option value="Bank Transfer">Τραπεζική Μεταφορά</option>
+                            <option value="Cash">Μετρητά</option>
+                            <option value="Cheque">Επιταγή</option>
+                            <option value="Credit Card">Πιστωτική Κάρτα</option>
+                            <option value="Other">Άλλο</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label">Αναφορά (προαιρετικό)</label>
+                        <input type="text" class="form-control" @bind="paymentReference"
+                               placeholder="Αριθμός συναλλαγής, επιταγής, κλπ." />
+                    </div>
+                </div>
+
+                <!-- Auto-allocate button + summary bar -->
+                <div class="d-flex align-items-center justify-content-between mb-3">
+                    <button class="btn btn-outline-primary btn-sm" @onclick="AutoAllocate"
+                            disabled="@(totalPaymentAmount <= 0)">
+                        <i class="bi bi-magic me-1"></i>Αυτόματη Κατανομή (Παλαιότερα Πρώτα)
+                    </button>
+                    <div class="d-flex gap-3 text-sm">
+                        <span>Σύνολο: <strong>€@totalPaymentAmount.ToString("N2")</strong></span>
+                        <span>Κατανεμημένο: <strong class="@(TotalAllocated > totalPaymentAmount ? "text-danger" : "text-success")">€@TotalAllocated.ToString("N2")</strong></span>
+                        <span>Αδιάθετο: <strong class="@(Unallocated < 0 ? "text-danger" : "")">€@Unallocated.ToString("N2")</strong></span>
+                    </div>
+                </div>
+
+                @if (!string.IsNullOrEmpty(errorMessage))
+                {
+                    <div class="alert alert-danger py-2">@errorMessage</div>
+                }
+
+                <!-- Invoice allocation table -->
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Τιμολόγιο</th>
+                                <th>Κατάσταση</th>
+                                <th class="text-end">Σύνολο</th>
+                                <th class="text-end">Πληρωμένο</th>
+                                <th class="text-end">Υπόλοιπο</th>
+                                <th style="width: 160px;">Κατανομή (€)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var invoice in OutstandingInvoices.OrderBy(i => i.CreatedDate))
+                            {
+                                var allocated = allocations.ContainsKey(invoice.Id) ? allocations[invoice.Id] : 0m;
+                                var isOverAllocated = allocated > invoice.RemainingAmount;
+                                <tr>
+                                    <td>
+                                        <span class="fw-semibold">@invoice.InvoiceNumber</span>
+                                        <div class="text-muted small">@invoice.CreatedDate.ToString("dd/MM/yyyy")</div>
+                                    </td>
+                                    <td>
+                                        <span class="badge @invoice.StatusBadgeClass">@invoice.StatusDisplay</span>
+                                    </td>
+                                    <td class="text-end">€@invoice.Total.ToString("N2")</td>
+                                    <td class="text-end">€@invoice.AmountPaid.ToString("N2")</td>
+                                    <td class="text-end fw-semibold">€@invoice.RemainingAmount.ToString("N2")</td>
+                                    <td>
+                                        <input type="number" class="form-control form-control-sm @(isOverAllocated ? "is-invalid" : "")"
+                                               value="@allocated"
+                                               @onchange="e => OnAllocationChanged(invoice.Id, invoice.RemainingAmount, e)"
+                                               step="0.01" min="0" max="@invoice.RemainingAmount" />
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" @onclick="OnCancel">Ακύρωση</button>
+                <button type="button" class="btn btn-success" @onclick="Confirm"
+                        disabled="@(!CanConfirm || isSubmitting)">
+                    @if (isSubmitting)
+                    {
+                        <span class="spinner-border spinner-border-sm me-1"></span>
+                    }
+                    Καταγραφή Πληρωμής
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Components/UI/BulkPaymentModal.razor.cs
+++ b/Components/UI/BulkPaymentModal.razor.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Components;
+using Invoqs.Models;
+
+namespace Invoqs.Components.UI
+{
+    public partial class BulkPaymentModal : ComponentBase
+    {
+        [Parameter] public List<InvoiceModel> OutstandingInvoices { get; set; } = new();
+        [Parameter] public EventCallback<BulkPaymentConfirmArgs> OnConfirm { get; set; }
+        [Parameter] public EventCallback OnCancel { get; set; }
+
+        private decimal totalPaymentAmount = 0m;
+        private DateTime paymentDate = DateTime.Today;
+        private string paymentMethod = "Bank Transfer";
+        private string? paymentReference;
+        private Dictionary<int, decimal> allocations = new();
+        private string errorMessage = "";
+        private bool isSubmitting = false;
+
+        private decimal TotalAllocated => allocations.Values.Sum();
+        private decimal Unallocated => totalPaymentAmount - TotalAllocated;
+        private bool CanConfirm =>
+            totalPaymentAmount > 0 &&
+            TotalAllocated > 0 &&
+            TotalAllocated <= totalPaymentAmount + 0.01m &&
+            allocations.All(a => a.Value <= (OutstandingInvoices.FirstOrDefault(i => i.Id == a.Key)?.RemainingAmount ?? 0) + 0.01m) &&
+            !isSubmitting;
+
+        protected override void OnInitialized()
+        {
+            foreach (var inv in OutstandingInvoices)
+                allocations[inv.Id] = 0m;
+        }
+
+        private void OnTotalAmountChanged(ChangeEventArgs e)
+        {
+            if (decimal.TryParse(e.Value?.ToString(), out var val))
+                totalPaymentAmount = val;
+            else
+                totalPaymentAmount = 0m;
+
+            errorMessage = "";
+        }
+
+        private void OnAllocationChanged(int invoiceId, decimal maxAmount, ChangeEventArgs e)
+        {
+            if (decimal.TryParse(e.Value?.ToString(), out var val))
+                allocations[invoiceId] = Math.Min(Math.Max(val, 0m), maxAmount);
+            else
+                allocations[invoiceId] = 0m;
+
+            errorMessage = "";
+        }
+
+        private void AutoAllocate()
+        {
+            var remaining = totalPaymentAmount;
+            foreach (var invoice in OutstandingInvoices.OrderBy(i => i.CreatedDate))
+            {
+                var canAllocate = Math.Min(remaining, invoice.RemainingAmount);
+                allocations[invoice.Id] = Math.Round(canAllocate, 2);
+                remaining -= canAllocate;
+                if (remaining <= 0.01m) break;
+            }
+            // zero out invoices not reached
+            foreach (var invoice in OutstandingInvoices)
+            {
+                if (!allocations.ContainsKey(invoice.Id))
+                    allocations[invoice.Id] = 0m;
+            }
+            errorMessage = "";
+        }
+
+        private async Task Confirm()
+        {
+            errorMessage = "";
+
+            if (TotalAllocated <= 0)
+            {
+                errorMessage = "Παρακαλώ κατανείμετε τουλάχιστον ένα ποσό σε ένα τιμολόγιο.";
+                return;
+            }
+
+            if (TotalAllocated > totalPaymentAmount + 0.01m)
+            {
+                errorMessage = "Το κατανεμημένο ποσό υπερβαίνει το συνολικό ποσό πληρωμής.";
+                return;
+            }
+
+            isSubmitting = true;
+
+            var activeAllocations = allocations
+                .Where(a => a.Value > 0)
+                .Select(a => (InvoiceId: a.Key, Amount: a.Value))
+                .ToList();
+
+            await OnConfirm.InvokeAsync(new BulkPaymentConfirmArgs
+            {
+                Allocations = activeAllocations,
+                PaymentDate = paymentDate,
+                PaymentMethod = paymentMethod,
+                PaymentReference = paymentReference
+            });
+
+            isSubmitting = false;
+        }
+    }
+
+    public class BulkPaymentConfirmArgs
+    {
+        public List<(int InvoiceId, decimal Amount)> Allocations { get; set; } = new();
+        public DateTime PaymentDate { get; set; }
+        public string PaymentMethod { get; set; } = "Bank Transfer";
+        public string? PaymentReference { get; set; }
+    }
+}

--- a/Interfaces/IInvoiceService.cs
+++ b/Interfaces/IInvoiceService.cs
@@ -19,6 +19,7 @@ namespace Invoqs.Interfaces
         Task<bool> MarkInvoiceAsDeliveredAsync(int invoiceId);
         Task<bool> RecordPaymentAsync(int invoiceId, decimal amount, DateTime paymentDate, string paymentMethod, string? paymentReference = null, string? notes = null);
         Task<bool> MarkInvoiceAsPaidAsync(int invoiceId, DateTime paidDate, string? paymentMethod = null, string? paymentReference = null);
+        Task<bool> RecordBulkPaymentAsync(List<(int InvoiceId, decimal Amount)> allocations, DateTime paymentDate, string paymentMethod, string? paymentReference = null, string? notes = null);
         Task<bool> CancelInvoiceAsync(int invoiceId, string? reason = null, string? notes = null);
 
         // Statistics

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -347,6 +347,39 @@ namespace Invoqs.Services
             }
         }
 
+        public async Task<bool> RecordBulkPaymentAsync(List<(int InvoiceId, decimal Amount)> allocations, DateTime paymentDate, string paymentMethod, string? paymentReference = null, string? notes = null)
+        {
+            try
+            {
+                var token = await _authService.GetTokenAsync();
+                _authService.AddAuthorizationHeader(_httpClient, token);
+
+                var request = new
+                {
+                    PaymentDate = paymentDate,
+                    PaymentMethod = paymentMethod,
+                    PaymentReference = paymentReference,
+                    Notes = notes,
+                    Allocations = allocations.Select(a => new { InvoiceId = a.InvoiceId, Amount = a.Amount }).ToList()
+                };
+
+                var response = await _httpClient.PostAsJsonAsync("invoices/bulk-payment", request);
+
+                if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                {
+                    await _authService.LogoutAsync();
+                    return false;
+                }
+
+                return response.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException ex)
+            {
+                Console.WriteLine($"Error recording bulk payment: {ex.Message}");
+                return false;
+            }
+        }
+
         public async Task<bool> CancelInvoiceAsync(int invoiceId, string? reason = null, string? notes = null)
         {
             try


### PR DESCRIPTION
Adds BulkPaymentModal with auto-allocate (oldest-first) and manual adjustment. Surfaces via a new Καταγραφή Πληρωμής button on the CustomerInvoices page when outstanding invoices exist.