### PR TITLE
Fix autocomplete inputs losing characters on fast typing

### DIFF
--- a/Components/Pages/AddJob.razor
+++ b/Components/Pages/AddJob.razor
@@ -92,8 +92,8 @@
                                     <label class="form-label required">Τίτλος Εργασίας</label>
                                     <div class="position-relative">
                                         <input type="text"
+                                               @ref="titleInputRef"
                                                class="@GetFieldErrorClass("Title")"
-                                               value="@titleInputValue"
                                                @oninput="OnTitleInput"
                                                @onfocus="OnTitleFocus"
                                                @onblur="HideTitleSuggestions"
@@ -273,8 +273,8 @@
                                     <label class="form-label required">Διεύθυνση Υπηρεσίας</label>
                                     <div class="position-relative">
                                         <input type="text"
+                                            @ref="addressInputRef"
                                             class="@GetFieldErrorClass("Address")"
-                                            value="@addressInputValue"
                                             @oninput="OnAddressInput"
                                             @onfocus="OnAddressFocus"
                                             @onblur="HideAddressSuggestions"

--- a/Components/Pages/AddJob.razor.cs
+++ b/Components/Pages/AddJob.razor.cs
@@ -31,6 +31,7 @@ namespace Invoqs.Components.Pages
         private ApiValidationError? validationErrors;
 
         // Address autocomplete properties
+        protected ElementReference addressInputRef;
         protected string addressInputValue = "";
         protected List<string> addressSuggestions = new();
         private List<string> allLoadedAddresses = new();
@@ -38,6 +39,7 @@ namespace Invoqs.Components.Pages
         protected bool isSearchingAddresses = false;
 
         // Title autocomplete properties
+        protected ElementReference titleInputRef;
         protected string titleInputValue = "";
         protected List<string> titleSuggestions = new();
         private List<string> allLoadedTitles = new();
@@ -172,13 +174,13 @@ namespace Invoqs.Components.Pages
             showTitleSuggestions = titleSuggestions.Any();
         }
 
-        protected void SelectTitle(string title)
+        protected async Task SelectTitle(string title)
         {
             titleInputValue = title;
             newJob.Title = title;
             showTitleSuggestions = false;
             titleSuggestions.Clear();
-            StateHasChanged();
+            await JSRuntime.InvokeVoidAsync("setInputValue", titleInputRef, title);
         }
 
         protected void HideTitleSuggestions()
@@ -390,14 +392,13 @@ namespace Invoqs.Components.Pages
             showAddressSuggestions = addressSuggestions.Any();
         }
 
-        protected void SelectAddress(string address)
+        protected async Task SelectAddress(string address)
         {
-            // Update both the input value and the model
             addressInputValue = address;
             newJob.Address = address;
             showAddressSuggestions = false;
             addressSuggestions.Clear();
-            StateHasChanged();
+            await JSRuntime.InvokeVoidAsync("setInputValue", addressInputRef, address);
         }
 
         protected void HideAddressSuggestions()

--- a/Components/Pages/EditJob.razor
+++ b/Components/Pages/EditJob.razor
@@ -94,7 +94,28 @@
                                 <!-- Job Title -->
                                 <div class="col-12">
                                     <label class="form-label required">Τίτλος Εργασίας</label>
-                                    <InputText @bind-Value="job.Title" class="@GetFieldErrorClass("Title")" placeholder="Εισάγετε τίτλο εργασίας" disabled="@isInvoiced" />
+                                    <div class="position-relative">
+                                        <input type="text"
+                                               @ref="titleInputRef"
+                                               class="@GetFieldErrorClass("Title")"
+                                               placeholder="Εισάγετε τίτλο εργασίας"
+                                               @oninput="OnTitleInput"
+                                               @onfocus="OnTitleFocus"
+                                               @onblur="HideTitleSuggestions"
+                                               disabled="@isInvoiced"
+                                               autocomplete="off" />
+                                        @if (showTitleSuggestions && titleSuggestions.Any())
+                                        {
+                                            <div class="address-suggestions">
+                                                @foreach (var suggestion in titleSuggestions)
+                                                {
+                                                    <div class="address-suggestion-item" @onmousedown="@(() => SelectTitle(suggestion))">
+                                                        @suggestion
+                                                    </div>
+                                                }
+                                            </div>
+                                        }
+                                    </div>
                                     <ValidationMessage For="@(() => job.Title)" class="text-danger small" />
                                     @if (validationErrors?.GetFieldErrors("Title").Any() == true)
                                     {
@@ -256,8 +277,8 @@
                                     <label class="form-label required">Διεύθυνση Υπηρεσίας</label>
                                     <div class="position-relative">
                                         <input type="text"
+                                               @ref="addressInputRef"
                                                class="@GetFieldErrorClass("Address")"
-                                               value="@addressInputValue"
                                                @oninput="OnAddressInput"
                                                @onfocus="OnAddressFocus"
                                                @onblur="HideAddressSuggestions"

--- a/Components/Pages/EditJob.razor.cs
+++ b/Components/Pages/EditJob.razor.cs
@@ -30,12 +30,22 @@ namespace Invoqs.Components.Pages
 
         private ApiValidationError? validationErrors;
 
+        // Title autocomplete properties
+        protected ElementReference titleInputRef;
+        protected string titleInputValue = "";
+        protected List<string> titleSuggestions = new();
+        private List<string> allLoadedTitles = new();
+        protected bool showTitleSuggestions = false;
+
         // Address autocomplete properties
+        protected ElementReference addressInputRef;
         protected string addressInputValue = "";
         protected List<string> addressSuggestions = new();
         private List<string> allLoadedAddresses = new(); // Store all addresses for client-side filtering
         protected bool showAddressSuggestions = false;
         protected bool isSearchingAddresses = false;
+
+        private bool _inputsInitialized = false;
 
         protected override async Task OnInitializedAsync()
         {
@@ -47,6 +57,16 @@ namespace Invoqs.Components.Pages
             if (JobId > 0)
             {
                 await LoadJob();
+            }
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (!isLoading && !_inputsInitialized && job != null)
+            {
+                _inputsInitialized = true;
+                await JSRuntime.InvokeVoidAsync("setInputValue", titleInputRef, titleInputValue);
+                await JSRuntime.InvokeVoidAsync("setInputValue", addressInputRef, addressInputValue);
             }
         }
 
@@ -70,7 +90,8 @@ namespace Invoqs.Components.Pages
                 isInvoiced = job.IsInvoiced;
                 isCustomerDeleted = job.CustomerIsDeleted;
 
-                // Initialize address input value with job's address
+                // Initialize input values with job's existing data
+                titleInputValue = job.Title ?? "";
                 addressInputValue = job.Address ?? "";
 
                 // Determine if job can be deleted
@@ -128,7 +149,8 @@ namespace Invoqs.Components.Pages
                 successMessage = "";
                 validationErrors = null;
 
-                // Sync the address from input to model before submitting
+                // Sync the inputs from input to model before submitting
+                job.Title = titleInputValue;
                 job.Address = addressInputValue;
 
                 var (success, errors) = await JobService.UpdateJobAsync(job);
@@ -273,10 +295,82 @@ namespace Invoqs.Components.Pages
             }
         }
 
+        protected async Task OnTitleFocus()
+        {
+            if (job == null) return;
+
+            if (job.CustomerId > 0 && !isInvoiced)
+                await LoadCustomerTitles();
+        }
+
+        private async Task LoadCustomerTitles()
+        {
+            if (job == null) return;
+
+            try
+            {
+                allLoadedTitles = await JobService.SearchTitlesAsync("", job.CustomerId);
+                titleSuggestions = allLoadedTitles;
+                showTitleSuggestions = titleSuggestions.Any();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading titles: {ex.Message}");
+                allLoadedTitles.Clear();
+                titleSuggestions.Clear();
+                showTitleSuggestions = false;
+            }
+        }
+
+        protected void OnTitleInput(ChangeEventArgs e)
+        {
+            if (job == null) return;
+
+            var value = e.Value?.ToString() ?? "";
+            titleInputValue = value;
+            job.Title = value;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                titleSuggestions = allLoadedTitles;
+                showTitleSuggestions = titleSuggestions.Any();
+                return;
+            }
+
+            titleSuggestions = allLoadedTitles
+                .Where(t => t.Contains(value, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            showTitleSuggestions = titleSuggestions.Any();
+        }
+
+        protected async Task SelectTitle(string title)
+        {
+            if (job == null) return;
+
+            titleInputValue = title;
+            job.Title = title;
+            showTitleSuggestions = false;
+            titleSuggestions.Clear();
+            await JSRuntime.InvokeVoidAsync("setInputValue", titleInputRef, title);
+        }
+
+        protected void HideTitleSuggestions()
+        {
+            Task.Delay(200).ContinueWith(_ =>
+            {
+                InvokeAsync(() =>
+                {
+                    showTitleSuggestions = false;
+                    StateHasChanged();
+                });
+            });
+        }
+
         protected async Task OnAddressFocus()
         {
             if (job == null) return;
-            
+
             // Show all customer addresses on focus
             if (job.CustomerId > 0 && !isInvoiced)
             {
@@ -372,16 +466,15 @@ namespace Invoqs.Components.Pages
             showAddressSuggestions = addressSuggestions.Any();
         }
 
-        protected void SelectAddress(string address)
+        protected async Task SelectAddress(string address)
         {
             if (job == null) return;
 
-            // Update both the input value and the model
             addressInputValue = address;
             job.Address = address;
             showAddressSuggestions = false;
             addressSuggestions.Clear();
-            StateHasChanged();
+            await JSRuntime.InvokeVoidAsync("setInputValue", addressInputRef, address);
         }
 
         protected void HideAddressSuggestions()

--- a/wwwroot/js/app.js
+++ b/wwwroot/js/app.js
@@ -1,3 +1,8 @@
+// Set an input element's value directly without Blazor re-render interference
+window.setInputValue = function (element, value) {
+    if (element) element.value = value;
+};
+
 // File download helper
 window.downloadFile = function (fileName, contentType, data) {
     // Convert byte array to blob


### PR DESCRIPTION
  Remove Blazor-controlled value binding from title and address autocomplete
  inputs in AddJob and EditJob. Re-renders triggered by the async focus API
  call were resetting the DOM input value mid-typing. Inputs are now
  uncontrolled — the browser owns the displayed value, with JS interop used
  to set initial values (EditJob) and push selected suggestions back to the
  input.