### PR TITLE
Fix setInputValue not found due to browser caching app.js

### DIFF
--- a/Components/App.razor
+++ b/Components/App.razor
@@ -33,10 +33,16 @@
 
    <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    
+
     <!-- Custom JS -->
     <script src="js/app.js"></script>
-    
+
+    <script>
+        window.setInputValue = function (element, value) {
+            if (element) element.value = value;
+        };
+    </script>
+
     <script src="_framework/blazor.server.js"></script>
 </body>
 

--- a/wwwroot/js/app.js
+++ b/wwwroot/js/app.js
@@ -1,8 +1,3 @@
-// Set an input element's value directly without Blazor re-render interference
-window.setInputValue = function (element, value) {
-    if (element) element.value = value;
-};
-
 // File download helper
 window.downloadFile = function (fileName, contentType, data) {
     // Convert byte array to blob


### PR DESCRIPTION
  Move setInputValue inline into App.razor so it is always part of the
  HTML document and cannot be served from a stale browser cache.
  Removed it from app.js to avoid duplication.